### PR TITLE
fix AD pub table bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ LazyData: true
 Imports:
     dccvalidator,
     dplyr,
-    easyPubMed,
     glue,
     purrr,
     readr,

--- a/R/pubmed.R
+++ b/R/pubmed.R
@@ -121,7 +121,7 @@ pub_query <- function(pub_pmids_list) {
 parse_summary_obj_list <- function(summary_obj_list) {
   # check that summary objec is not NA
   # pull out author doi
-  if (!is.na(summary_obj_list)){
+  if (any(!is.na(summary_obj_list))) {
 
     # pull out author and doi (nested dataframes)
     author_doi_list <- lapply(seq_along(summary_obj_list), function(i) {

--- a/R/pubmed.R
+++ b/R/pubmed.R
@@ -115,11 +115,8 @@ pub_query <- function(pub_pmids_list) {
 #' @return dataframe containing authors and doi for each summary object in the list.
 #'
 
-# TODO FIX WARNGING : In if (suppressWarnings(!is.na(summary_obj_list))) { :
-# the condition has length > 1 and only the first element will be used
-
 parse_summary_obj_list <- function(summary_obj_list) {
-  # check that summary objec is not NA
+  # check that at least one element of summary object is not NA
   # pull out author doi
   if (any(!is.na(summary_obj_list))) {
 


### PR DESCRIPTION
The `parse_summary_obj_list()` function was failing to execute when !is.na(summary_obj_list) returned a list of length > 1 (e.g, 54 elements of the summary_obj_list and none of them are NA, so a list of 54 TRUE values). Maybe it used to just be a warning but now it was causing the publication update script to exit. 

Also cleaned up the imports a bit to remove easyPubMed, since that is out of our lives for good.